### PR TITLE
fix handling of root dir

### DIFF
--- a/src/AliyunOssAdapter.php
+++ b/src/AliyunOssAdapter.php
@@ -275,8 +275,8 @@ class AliyunOssAdapter extends AbstractAdapter
      */
     public function listContents($directory = '', $recursive = false)
     {
-        $directory = $this->applyPathPrefix($directory);
         $directory = $this->applyPathSeparator($directory);
+        $directory = $this->applyPathPrefix($directory);
 
         $bucket = $this->bucket;
         $delimiter = '/';


### PR DESCRIPTION
Fixes handling of root directory "/" (or "").

Fixes problem with listing contents of root directory: 

$adapter->listContents(''); 
or
$adapter->listContents('/');

This also fixes OssException that is thrown when trying to delete an empty directory:

$adapter->deleteDir('empty-dir');